### PR TITLE
Send new message on any open PR and optimize API call flow

### DIFF
--- a/.github/workflows/build-and-run.yml
+++ b/.github/workflows/build-and-run.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: "1.22"
 
@@ -28,4 +28,4 @@ jobs:
         run: go build -o bin/main cmd/main.go
 
       - name: Run
-        run: ./bin/main ${{ github.event.client_payload.repo }}
+        run: ./bin/main '${{ toJson(github.event.client_payload) }}'

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: "1.22"
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"encoding/json"
 	"os"
 
 	"github.com/ichiro-its/discord-pr-bot/config"
+	"github.com/ichiro-its/discord-pr-bot/entity"
 	"github.com/ichiro-its/discord-pr-bot/handler"
 	"github.com/joho/godotenv"
 )
@@ -11,14 +13,19 @@ import (
 func main() {
 	godotenv.Load()
 	if len(os.Args) < 2 {
-		panic("missing repo argument")
+		panic("missing parameter argument")
 	}
 	cfg := config.LoadConfig()
 	bot, err := handler.NewBot(cfg)
 	if err != nil {
 		panic(err)
 	}
-	err = bot.Process(os.Args[1])
+	botParam := &entity.BotParam{}
+	err = json.Unmarshal([]byte(os.Args[1]), botParam)
+	if err != nil {
+		panic(err)
+	}
+	err = bot.Process(botParam)
 	if err != nil {
 		panic(err)
 	}

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -12,4 +12,6 @@ const (
 
 	GithubTokenEnv = "GITHUB_TOKEN"
 	GithubOrgEnv   = "GITHUB_ORG"
+
+	GithubPrTypeOpened = "opened"
 )

--- a/entity/bot_param.go
+++ b/entity/bot_param.go
@@ -1,0 +1,6 @@
+package entity
+
+type BotParam struct {
+	Repository string `json:"repository"`
+	PrType     string `json:"pr_type"`
+}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/bwmarrin/discordgo v0.28.1
 	github.com/joho/godotenv v1.5.1
 	github.com/stretchr/testify v1.9.0
+	golang.org/x/sync v0.7.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,8 @@ golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/oauth2 v0.21.0 h1:tsimM75w1tF/uws5rbeHzIWxEqElMehnc+iW793zsZs=
 golang.org/x/oauth2 v0.21.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
+golang.org/x/sync v0.7.0 h1:YsImfSBoP9QPYL0xyKJPq0gcaJdG3rInoqxTWbfQu9M=
+golang.org/x/sync v0.7.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68 h1:nxC68pudNYkKU6jWhgrqdreuFiOQWj1Fs7T3VrH4Pjw=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=


### PR DESCRIPTION
This pull request includes changes to send a new message on any open pull request to keep the notification fresh and optimize the flow by adding concurrency in API calls 